### PR TITLE
use java's CLASSPATH to find tika-app.jar

### DIFF
--- a/analyze/src/Tika.hs
+++ b/analyze/src/Tika.hs
@@ -5,18 +5,25 @@ module Tika where
 import           Data.List         (isPrefixOf)
 import           GHC.IO.Exception
 import           Prelude.Unicode
+import           System.Environment (lookupEnv)
 import           System.Process    (readProcessWithExitCode)
 import           Text.HandsomeSoup
 import           Text.XML.HXT.Core (getText, hread, runLA, (//>), (>>>))
 
-jarFile        = "/Users/robb/lib/tika-app.jar"
-javaExecutable = "java"
+jarFile ∷ String
+jarFile = "tika-app.jar"
 
+java ∷ [String] → IO (ExitCode, String, String)
+java args = readProcessWithExitCode "java" args ""
 
 
 runTika ∷ String → IO (ExitCode, String, String)
-runTika pdfFilename =
-  readProcessWithExitCode javaExecutable ["-jar", jarFile, "--html", pdfFilename] ""
+runTika pdfFilename = do
+  classpath <- lookupEnv "CLASSPATH"
+  let args = ["--html", pdfFilename]
+  case classpath of
+    Nothing -> java ("-jar":jarFile:args)
+    Just _  -> java ("org.apache.tika.cli.TikaCLI":args)
 
 
 paragraphs ∷ String → [String]

--- a/analyze/stack.yaml
+++ b/analyze/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.10
+resolver: lts-8.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
- it makes sense to look in the current directory for tika-app.jar by default
- use lts-8.6 because it compiles and stack's 7.10.3 doesn't work on archlinux

Fixes #1