### PR TITLE
New CLI with `optparse-applicative`

### DIFF
--- a/analyze/analyze.cabal
+++ b/analyze/analyze.cabal
@@ -16,19 +16,22 @@ executable analyze
   ghc-options:         -Wall -fno-warn-missing-signatures
   hs-source-dirs:      src
   main-is:             Main.hs
-  other-modules:       StringOps, Amendment, Tika
+  other-modules:       Amendment
+                       , Cli
+                       , StringOps
+                       , Tika
   default-language:    Haskell2010
+  default-extensions:  UnicodeSyntax
   build-depends:       base >= 4.7 && < 5
                        , aeson
                        , aeson-pretty
                        , base-unicode-symbols
                        , bytestring
                        , HandsomeSoup
-                       , hspec
                        , hxt
                        , MissingH
+                       , optparse-applicative
                        , process
-                       , QuickCheck
                        , regex-tdfa
                        , time
                        , text
@@ -40,6 +43,7 @@ test-suite tests
   other-modules:       Amendment, AmendmentSpec, StringOps, StringOpsSpec, Tika
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
+  default-extensions:  UnicodeSyntax
   build-depends:       base >= 4.7 && < 5
                        , aeson
                        , aeson-pretty

--- a/analyze/src/Amendment.hs
+++ b/analyze/src/Amendment.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE UnicodeSyntax #-}
 
 module Amendment where
 

--- a/analyze/src/Cli.hs
+++ b/analyze/src/Cli.hs
@@ -1,0 +1,45 @@
+module Cli
+  ( Options(..)
+  , getOptions
+  ) where
+
+import           Options.Applicative
+
+data Options =
+  Options {
+    inputFilePath  ∷ FilePath,
+    tikaJarPath    ∷ FilePath,
+    javaExecutable ∷ String
+  } deriving (Show)
+
+
+getOptions ∷ IO Options
+getOptions = execParser cli
+
+
+cli ∷ ParserInfo Options
+cli = info (optionsP <**> helper)
+   ( fullDesc
+  <> progDesc "Extracts Oregon session law metadata."
+  <> header   "A command line app, which pulls in an Oregon session law\
+              \ in PDF format and extracts this metadata to JSON." )
+
+
+optionsP ∷ Parser Options
+optionsP =
+  Options
+  <$> argument str
+     ( metavar "FILENAME"
+    <> help    "Path to .PFD-file" )
+  <*> strOption
+     ( short   't'
+    <> long    "tika-jar"
+    <> value   "/usr/local/lib/tika-app.jar"
+    <> metavar "PATH_TO_JAR"
+    <> help    "Path to Tika's .JAR-file" )
+  <*> strOption
+     ( short   'j'
+    <> long    "java-executable"
+    <> value   "java"
+    <> metavar "JAVA_EXECUTABLE"
+    <> help    "Name of Java exacutable" )

--- a/analyze/src/Cli.hs
+++ b/analyze/src/Cli.hs
@@ -8,7 +8,7 @@ import           Options.Applicative
 data Options =
   Options {
     inputFilePath  ∷ FilePath,
-    tikaJarPath    ∷ FilePath,
+    tikaJarPath    ∷ Maybe FilePath,
     javaExecutable ∷ String
   } deriving (Show)
 
@@ -31,12 +31,12 @@ optionsP =
   <$> argument str
      ( metavar "FILENAME"
     <> help    "Path to .PFD-file" )
-  <*> strOption
-     ( short   't'
-    <> long    "tika-jar"
-    <> value   "/usr/local/lib/tika-app.jar"
-    <> metavar "PATH_TO_JAR"
-    <> help    "Path to Tika's .JAR-file" )
+  <*> optional
+     ( strOption
+        ( short   't'
+       <> long    "tika-jar"
+       <> metavar "PATH_TO_JAR"
+       <> help    "Path to Tika's .JAR-file" ) )
   <*> strOption
      ( short   'j'
     <> long    "java-executable"

--- a/analyze/src/Main.hs
+++ b/analyze/src/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UnicodeSyntax #-}
-
 module Main where
 
 import           Amendment
@@ -10,18 +8,13 @@ import qualified Data.ByteString.Lazy     as B
 import           Data.Eq.Unicode
 import           Data.Function            ((&))
 import           GHC.IO.Exception
-import           System.Environment       (getArgs)
+import           Cli
 import           Tika
 
 
 main ∷ IO ()
 main = do
-  args ← getArgs
-  when (length args ≠ 1)
-    (fail "Usage: analyze [filename]")
-
-  let pdfFilename = head args
-  (errCode, rawHTML, stderr') ← runTika pdfFilename
+  (errCode, rawHTML, stderr') ← runTika =<< getOptions
   when (errCode ≠ ExitSuccess)
     (fail stderr')
 

--- a/analyze/src/StringOps.hs
+++ b/analyze/src/StringOps.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UnicodeSyntax #-}
-
 module StringOps(cleanUp, firstMatch, join, fixHyphenation, fixWhitespace) where
 
 import           Control.Arrow.Unicode

--- a/analyze/src/Tika.hs
+++ b/analyze/src/Tika.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE UnicodeSyntax #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Tika where
 
+import           Cli
 import           Data.List         (isPrefixOf)
 import           GHC.IO.Exception
 import           Prelude.Unicode
@@ -9,14 +10,15 @@ import           System.Process    (readProcessWithExitCode)
 import           Text.HandsomeSoup
 import           Text.XML.HXT.Core (getText, hread, runLA, (//>), (>>>))
 
-jarFile        = "/Users/robb/lib/tika-app.jar"
-javaExecutable = "java"
 
-
-
-runTika ∷ String → IO (ExitCode, String, String)
-runTika pdfFilename =
-  readProcessWithExitCode javaExecutable ["-jar", jarFile, "--html", pdfFilename] ""
+runTika ∷ Options → IO (ExitCode, String, String)
+runTika Options{..} =
+  readProcessWithExitCode
+    javaExecutable
+    [ "-jar", tikaJarPath
+    , "--html", inputFilePath
+    ]
+    ""
 
 
 paragraphs ∷ String → [String]

--- a/analyze/src/Tika.hs
+++ b/analyze/src/Tika.hs
@@ -20,7 +20,7 @@ runTika ∷ Options → IO (ExitCode, String, String)
 runTika Options{..} = do
   classpath <- lookupEnv "CLASSPATH"
   case (classpath, tikaJarPath) of
-    (_, Just path) -> runWith ["-cp", path]
+    (_, Just path) -> runWith ["-jar", path]
     (Just _,    _) -> runWith []
     _              ->
       return ( ExitFailure 1

--- a/analyze/src/Tika.hs
+++ b/analyze/src/Tika.hs
@@ -21,7 +21,7 @@ runTika Options{..} = do
   classpath <- lookupEnv "CLASSPATH"
   case (classpath, tikaJarPath) of
     (_, Just path) -> runWith ["-jar", path]
-    (Just _,    _) -> runWith []
+    (Just _,    _) -> runWith [tikaClass]
     _              ->
       return ( ExitFailure 1
              , ""
@@ -30,7 +30,7 @@ runTika Options{..} = do
     runWith params =
       readProcessWithExitCode
         javaExecutable
-        (params ++ [tikaClass, "--html", inputFilePath])
+        (params ++ ["--html", inputFilePath])
         ""
 
 


### PR DESCRIPTION
New CLI is more safe (no more `head`, see #2) and more user-frienldy (shows full help with `--help` option).
Also it gives two new options: path to Tika's `.jar` file(*) and Java executable name (closes #1).

*) If not `--tika-jar` specified then program will use Java's `CLASSPATH` env variable.